### PR TITLE
36 create api key endpoints

### DIFF
--- a/backend/src/database/crud/api_key_model.py
+++ b/backend/src/database/crud/api_key_model.py
@@ -2,7 +2,7 @@ from sqlalchemy.orm import Session
 
 from backend.src.database.models.api_key_model import ApiKey
 from backend.src.database.models.user_model import User
-from backend.src.schemas.model.api_key_schema import ApiKeyCreate
+from backend.src.schemas.model.api_key_schema import ApiKeyCreate, ApiKeyUpdate, ApiKeyDelete
 from backend.src.services.auth.security_service import encrypt_data
 
 def get_api_keys(db : Session):
@@ -22,3 +22,23 @@ def create_api_key(db: Session, new_api_key: ApiKeyCreate, current_user: User):
     db.commit()
     db.refresh(db_api_key)
     return db_api_key
+
+def update_api_key(db : Session, new_api_key: ApiKeyUpdate, current_user: User):
+    record = db.query(ApiKey).filter_by(
+        user_id=current_user.id,
+        broker_name=new_api_key.broker_name
+    ).first()
+
+    record.api_key = encrypt_data(new_api_key.api_key, new_api_key.secret_key)
+    record.private_key = encrypt_data(new_api_key.private_key, new_api_key.secret_key)
+
+    db.commit()
+    db.refresh(record)
+    return record
+
+def delete_api_key(db: Session, api_key: ApiKeyDelete, current_user: User):
+    record = get_api_key(db, current_user.id, api_key.broker_name)
+    db.delete(record)
+    db.commit()
+    db.refresh(record)
+    return record

--- a/backend/src/database/crud/api_key_model.py
+++ b/backend/src/database/crud/api_key_model.py
@@ -39,8 +39,8 @@ def update_api_key(db : Session, new_api_key: ApiKeyUpdate, current_user: User):
     db.refresh(record)
     return record
 
-def delete_api_key(db: Session, api_key: ApiKeyDelete, current_user: User):
-    record = get_api_key(db, current_user.id, api_key.broker_name)
+def delete_db_api_key(db: Session, api_key: ApiKeyDelete, user_id: int):
+    record = get_api_key(db, user_id, api_key.broker_name)
     db.delete(record)
     db.commit()
     db.refresh(record)

--- a/backend/src/database/crud/api_key_model.py
+++ b/backend/src/database/crud/api_key_model.py
@@ -5,16 +5,16 @@ from backend.src.database.models.user_model import User
 from backend.src.schemas.model.api_key_schema import ApiKeyCreate, ApiKeyUpdate, ApiKeyDelete
 from backend.src.services.auth.security_service import encrypt_data
 
-def get_api_keys(db : Session):
+def get_db_api_keys(db : Session):
     return db.query(ApiKey).all()
 
-def get_api_key(db: Session, user_id: int, broker_name: str):
+def get_db_api_key(db: Session, user_id: int, broker_name: str):
     return db.query(ApiKey).filter_by(user_id=user_id, broker_name=broker_name).first()
 
-def get_api_keys_by_user_id(db : Session, user_id: int):
+def get_db_api_keys_by_user_id(db : Session, user_id: int):
     return db.query(ApiKey).filter_by(user_id=user_id).all()
 
-def create_api_key(db: Session, new_api_key: ApiKeyCreate, current_user: User):
+def create_db_api_key(db: Session, new_api_key: ApiKeyCreate, current_user: User):
     db_api_key = ApiKey(
         api_key=encrypt_data(new_api_key.api_key, new_api_key.secret_key),
         private_key=encrypt_data(new_api_key.private_key, new_api_key.secret_key),
@@ -26,7 +26,7 @@ def create_api_key(db: Session, new_api_key: ApiKeyCreate, current_user: User):
     db.refresh(db_api_key)
     return db_api_key
 
-def update_api_key(db : Session, new_api_key: ApiKeyUpdate, current_user: User):
+def update_db_api_key(db : Session, new_api_key: ApiKeyUpdate, current_user: User):
     record = db.query(ApiKey).filter_by(
         user_id=current_user.id,
         broker_name=new_api_key.broker_name
@@ -40,7 +40,7 @@ def update_api_key(db : Session, new_api_key: ApiKeyUpdate, current_user: User):
     return record
 
 def delete_db_api_key(db: Session, api_key: ApiKeyDelete, user_id: int):
-    record = get_api_key(db, user_id, api_key.broker_name)
+    record = get_db_api_key(db, user_id, api_key.broker_name)
     db.delete(record)
     db.commit()
     db.refresh(record)

--- a/backend/src/database/crud/api_key_model.py
+++ b/backend/src/database/crud/api_key_model.py
@@ -1,6 +1,7 @@
 from sqlalchemy.orm import Session
 
 from backend.src.database.models.api_key_model import ApiKey
+from backend.src.database.models.user_model import User
 from backend.src.schemas.model.api_key_schema import ApiKeyCreate
 from backend.src.services.auth.security_service import encrypt_data
 
@@ -10,11 +11,11 @@ def get_api_keys(db : Session):
 def get_api_key(db: Session, user_id: int, broker_name: str):
     return db.query(ApiKey).filter_by(user_id=user_id, broker_name=broker_name).first()
 
-def create_api_key(db: Session, new_api_key: ApiKeyCreate):
+def create_api_key(db: Session, new_api_key: ApiKeyCreate, current_user: User):
     db_api_key = ApiKey(
         api_key=encrypt_data(new_api_key.api_key, new_api_key.secret_key),
         private_key=encrypt_data(new_api_key.private_key, new_api_key.secret_key),
-        user_id=new_api_key.user_id,
+        user_id=current_user.id,
         broker_name=new_api_key.broker_name
     )
     db.add(db_api_key)

--- a/backend/src/database/crud/api_key_model.py
+++ b/backend/src/database/crud/api_key_model.py
@@ -11,6 +11,9 @@ def get_api_keys(db : Session):
 def get_api_key(db: Session, user_id: int, broker_name: str):
     return db.query(ApiKey).filter_by(user_id=user_id, broker_name=broker_name).first()
 
+def get_api_keys_by_user_id(db : Session, user_id: int):
+    return db.query(ApiKey).filter_by(user_id=user_id).all()
+
 def create_api_key(db: Session, new_api_key: ApiKeyCreate, current_user: User):
     db_api_key = ApiKey(
         api_key=encrypt_data(new_api_key.api_key, new_api_key.secret_key),

--- a/backend/src/database/crud/api_key_model.py
+++ b/backend/src/database/crud/api_key_model.py
@@ -7,10 +7,10 @@ from backend.src.services.auth.security_service import encrypt_data
 def get_api_key(db: Session, user_id: int, broker_name: str):
     return db.query(ApiKey).filter_by(user_id=user_id, broker_name=broker_name).first()
 
-def create_api_key(db: Session, new_api_key: ApiKeyCreate, secret_key: str):
-    db_api_key = ApiKeyCreate(
-        api_key=encrypt_data(new_api_key.api_key, secret_key),
-        private_key=encrypt_data(new_api_key.private_key, secret_key),
+def create_api_key(db: Session, new_api_key: ApiKeyCreate):
+    db_api_key = ApiKey(
+        api_key=encrypt_data(new_api_key.api_key, new_api_key.secret_key),
+        private_key=encrypt_data(new_api_key.private_key, new_api_key.secret_key),
         user_id=new_api_key.user_id,
         broker_name=new_api_key.broker_name
     )

--- a/backend/src/database/crud/api_key_model.py
+++ b/backend/src/database/crud/api_key_model.py
@@ -14,10 +14,15 @@ def get_db_api_key(db: Session, user_id: int, broker_name: str):
 def get_db_api_keys_by_user_id(db : Session, user_id: int):
     return db.query(ApiKey).filter_by(user_id=user_id).all()
 
-def create_db_api_key(db: Session, new_api_key: ApiKeyCreate, current_user: User):
+def create_db_api_key(
+        db: Session,
+        new_api_key: ApiKeyCreate,
+        secret_key: str,
+        current_user: User
+):
     db_api_key = ApiKey(
-        api_key=encrypt_data(new_api_key.api_key, new_api_key.secret_key),
-        private_key=encrypt_data(new_api_key.private_key, new_api_key.secret_key),
+        api_key=encrypt_data(new_api_key.api_key, secret_key),
+        private_key=encrypt_data(new_api_key.private_key, secret_key),
         user_id=current_user.id,
         broker_name=new_api_key.broker_name
     )
@@ -26,14 +31,19 @@ def create_db_api_key(db: Session, new_api_key: ApiKeyCreate, current_user: User
     db.refresh(db_api_key)
     return db_api_key
 
-def update_db_api_key(db : Session, new_api_key: ApiKeyUpdate, current_user: User):
+def update_db_api_key(
+        db : Session,
+        new_api_key: ApiKeyUpdate,
+        secret_key: str,
+        current_user: User
+):
     record = db.query(ApiKey).filter_by(
         user_id=current_user.id,
         broker_name=new_api_key.broker_name
     ).first()
 
-    record.api_key = encrypt_data(new_api_key.api_key, new_api_key.secret_key)
-    record.private_key = encrypt_data(new_api_key.private_key, new_api_key.secret_key)
+    record.api_key = encrypt_data(new_api_key.api_key, secret_key)
+    record.private_key = encrypt_data(new_api_key.private_key, secret_key)
 
     db.commit()
     db.refresh(record)

--- a/backend/src/database/crud/api_key_model.py
+++ b/backend/src/database/crud/api_key_model.py
@@ -18,12 +18,12 @@ def create_db_api_key(
         db: Session,
         new_api_key: ApiKeyCreate,
         secret_key: str,
-        current_user: User
+        user_id: int
 ):
     db_api_key = ApiKey(
         api_key=encrypt_data(new_api_key.api_key, secret_key),
         private_key=encrypt_data(new_api_key.private_key, secret_key),
-        user_id=current_user.id,
+        user_id=user_id,
         broker_name=new_api_key.broker_name
     )
     db.add(db_api_key)
@@ -35,10 +35,10 @@ def update_db_api_key(
         db : Session,
         new_api_key: ApiKeyUpdate,
         secret_key: str,
-        current_user: User
+        user_id: int
 ):
     record = db.query(ApiKey).filter_by(
-        user_id=current_user.id,
+        user_id=user_id,
         broker_name=new_api_key.broker_name
     ).first()
 

--- a/backend/src/database/crud/api_key_model.py
+++ b/backend/src/database/crud/api_key_model.py
@@ -4,6 +4,9 @@ from backend.src.database.models.api_key_model import ApiKey
 from backend.src.schemas.model.api_key_schema import ApiKeyCreate
 from backend.src.services.auth.security_service import encrypt_data
 
+def get_api_keys(db : Session):
+    return db.query(ApiKey).all()
+
 def get_api_key(db: Session, user_id: int, broker_name: str):
     return db.query(ApiKey).filter_by(user_id=user_id, broker_name=broker_name).first()
 

--- a/backend/src/database/crud/api_key_model.py
+++ b/backend/src/database/crud/api_key_model.py
@@ -43,5 +43,4 @@ def delete_db_api_key(db: Session, api_key: ApiKeyDelete, user_id: int):
     record = get_db_api_key(db, user_id, api_key.broker_name)
     db.delete(record)
     db.commit()
-    db.refresh(record)
     return record

--- a/backend/src/database/crud/broker_model.py
+++ b/backend/src/database/crud/broker_model.py
@@ -6,13 +6,13 @@ from backend.src.database.models.broker_model import Broker
 from backend.src.schemas.model.broker_schema import BrokerCreate
 
 
-def get_brokers(db : Session):
+def get_db_brokers(db : Session):
     return db.query(Broker).all()
 
-def get_broker(db: Session, broker_name: str):
+def get_db_broker(db: Session, broker_name: str):
     return db.query(Broker).filter(Broker.name == broker_name).first()
 
-def add_broker(db : Session, broker: BrokerCreate):
+def add_db_broker(db : Session, broker: BrokerCreate):
     db_broker = Broker(
         name=broker.name
     )
@@ -33,5 +33,5 @@ def add_broker_from_file(db : Session, file_path : str = None):
     broker_names = [name.strip() for name in broker_names]
 
     for name in broker_names:
-        if get_broker(db, name) is None:
-            db_broker = add_broker(db, BrokerCreate(name=name))
+        if get_db_broker(db, name) is None:
+            add_db_broker(db, BrokerCreate(name=name))

--- a/backend/src/database/crud/user_crud.py
+++ b/backend/src/database/crud/user_crud.py
@@ -5,16 +5,16 @@ from backend.src.schemas.model.user_schema import UserCreate
 from backend.src.services.auth.security_service import hash_password
 
 
-def get_users(db: Session):
+def get_db_users(db: Session):
     return db.query(User).all()
 
-def get_user(db: Session, user_id: int) -> type[User] | None:
+def get_db_user(db: Session, user_id: int) -> type[User] | None:
     return db.query(User).filter(User.id == user_id).first()
 
-def get_user_by_email(db: Session, email: str) -> type[User] | None:
+def get_db_user_by_email(db: Session, email: str) -> type[User] | None:
     return db.query(User).filter(User.email == email).first()
 
-def create_user(db: Session, user: UserCreate) -> User:
+def create_db_user(db: Session, user: UserCreate) -> User:
     db_user = User(
         email=str(user.email),
         password=hash_password(user.password),

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -4,12 +4,14 @@ from fastapi import FastAPI
 from backend.src.database.crud.broker_model import add_broker_from_file
 from backend.src.database.session import get_db
 from backend.src.routes.auth.auth_router import auth_router
+from backend.src.routes.models.api_key_router import api_key_router
 from backend.src.routes.models.user_router import user_router
 
 app = FastAPI()
 
 app.include_router(auth_router, prefix="/api")
 app.include_router(user_router, prefix="/api")
+app.include_router(api_key_router, prefix="/api")
 
 if __name__ == "__main__":
     add_broker_from_file(next(get_db()))

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from backend.src.database.crud.broker_model import add_broker_from_file
 from backend.src.database.session import get_db
 from backend.src.routes.auth.auth_router import auth_router
+from backend.src.routes.auth.security_router import security_router
 from backend.src.routes.models.api_key_router import api_key_router
 from backend.src.routes.models.user_router import user_router
 
@@ -12,6 +13,7 @@ app = FastAPI()
 app.include_router(auth_router, prefix="/api")
 app.include_router(user_router, prefix="/api")
 app.include_router(api_key_router, prefix="/api")
+app.include_router(security_router, prefix="/api")
 
 if __name__ == "__main__":
     add_broker_from_file(next(get_db()))

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -6,6 +6,7 @@ from backend.src.database.session import get_db
 from backend.src.routes.auth.auth_router import auth_router
 from backend.src.routes.auth.security_router import security_router
 from backend.src.routes.models.api_key_router import api_key_router
+from backend.src.routes.models.broker_router import broker_router
 from backend.src.routes.models.user_router import user_router
 
 app = FastAPI()
@@ -14,6 +15,7 @@ app.include_router(auth_router, prefix="/api")
 app.include_router(user_router, prefix="/api")
 app.include_router(api_key_router, prefix="/api")
 app.include_router(security_router, prefix="/api")
+app.include_router(broker_router, prefix="/api")
 
 if __name__ == "__main__":
     add_broker_from_file(next(get_db()))

--- a/backend/src/routes/auth/auth_router.py
+++ b/backend/src/routes/auth/auth_router.py
@@ -11,7 +11,7 @@ from backend.src.services.auth.auth_service import authenticate_user, create_acc
 
 auth_router = APIRouter(
     prefix='/auth',
-    tags=['auth'],
+    tags=['Authentication'],
 )
 
 @auth_router.post('/login')

--- a/backend/src/routes/auth/security_router.py
+++ b/backend/src/routes/auth/security_router.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, Depends
+
+from backend.src.database.models.user_model import User
+from backend.src.schemas.auth.security_schema import ResponseSchema, DeriveKeyRequest
+from backend.src.services.auth.auth_service import get_current_user
+from backend.src.services.auth.security_service import generate_key_from_password
+
+security_router = APIRouter(
+    prefix="/encryption",
+    tags=["Encryption"]
+)
+
+@security_router.get("/derive-key", response_model=ResponseSchema)
+def derive_key(request : DeriveKeyRequest, user : User = Depends(get_current_user)):
+    return generate_key_from_password(user.id, request.password)

--- a/backend/src/routes/auth/security_router.py
+++ b/backend/src/routes/auth/security_router.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, Security
 
 from backend.src.database.models.user_model import User
 from backend.src.schemas.auth.security_schema import SecurityUserPassword
-from backend.src.services.auth.auth_service import get_current_user
+from backend.src.services.auth.auth_service import get_current_active_user
 from backend.src.services.auth.security_service import generate_key_from_password
 
 security_router = APIRouter(
@@ -11,5 +11,5 @@ security_router = APIRouter(
 )
 
 @security_router.post("/derive-key")
-def derive_key(password: SecurityUserPassword, user: User = Depends(get_current_user)):
+def derive_key(password: SecurityUserPassword, user: User = Depends(get_current_active_user)):
     return generate_key_from_password(user.id, password.password)

--- a/backend/src/routes/auth/security_router.py
+++ b/backend/src/routes/auth/security_router.py
@@ -1,7 +1,6 @@
 from fastapi import APIRouter, Depends
 
 from backend.src.database.models.user_model import User
-from backend.src.schemas.auth.security_schema import ResponseSchema, DeriveKeyRequest
 from backend.src.services.auth.auth_service import get_current_user
 from backend.src.services.auth.security_service import generate_key_from_password
 
@@ -10,17 +9,6 @@ security_router = APIRouter(
     tags=["Encryption"]
 )
 
-@security_router.post("/derive-key", response_model=ResponseSchema)
-def derive_key(request : DeriveKeyRequest, user : User = Depends(get_current_user)):
-    """
-    Derive an encryption key from a password.
-
-    This endpoint does not mutate server-side resources, however to avoid logging the password in the url,
-    we are using a query instead.
-
-    :param request: A query schema for the password.
-    :param user: The authenticated user to derive an encryption key for.
-
-    :return: An encryption key to be stored.
-    """
-    return generate_key_from_password(user.id, request.password)
+@security_router.get("/derive-key")
+def derive_key(password : str, user : User = Depends(get_current_user)):
+    return generate_key_from_password(user.id, password)

--- a/backend/src/routes/auth/security_router.py
+++ b/backend/src/routes/auth/security_router.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends
 
 from backend.src.database.models.user_model import User
+from backend.src.schemas.auth.security_schema import SecurityUserPassword
 from backend.src.services.auth.auth_service import get_current_user
 from backend.src.services.auth.security_service import generate_key_from_password
 
@@ -10,5 +11,5 @@ security_router = APIRouter(
 )
 
 @security_router.get("/derive-key")
-def derive_key(password : str, user : User = Depends(get_current_user)):
-    return generate_key_from_password(user.id, password)
+def derive_key(credentials: SecurityUserPassword, user: User = Depends(get_current_user)):
+    return generate_key_from_password(user.id, credentials.password)

--- a/backend/src/routes/auth/security_router.py
+++ b/backend/src/routes/auth/security_router.py
@@ -10,6 +10,17 @@ security_router = APIRouter(
     tags=["Encryption"]
 )
 
-@security_router.get("/derive-key", response_model=ResponseSchema)
+@security_router.post("/derive-key", response_model=ResponseSchema)
 def derive_key(request : DeriveKeyRequest, user : User = Depends(get_current_user)):
+    """
+    Derive an encryption key from a password.
+
+    This endpoint does not mutate server-side resources, however to avoid logging the password in the url,
+    we are using a query instead.
+
+    :param request: A query schema for the password.
+    :param user: The authenticated user to derive an encryption key for.
+
+    :return: An encryption key to be stored.
+    """
     return generate_key_from_password(user.id, request.password)

--- a/backend/src/routes/auth/security_router.py
+++ b/backend/src/routes/auth/security_router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Security
 
 from backend.src.database.models.user_model import User
 from backend.src.schemas.auth.security_schema import SecurityUserPassword
@@ -10,6 +10,6 @@ security_router = APIRouter(
     tags=["Encryption"]
 )
 
-@security_router.get("/derive-key")
-def derive_key(credentials: SecurityUserPassword, user: User = Depends(get_current_user)):
-    return generate_key_from_password(user.id, credentials.password)
+@security_router.post("/derive-key")
+def derive_key(password: SecurityUserPassword, user: User = Depends(get_current_user)):
+    return generate_key_from_password(user.id, password.password)

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -1,11 +1,12 @@
-from typing import List
+from typing import List, Any
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
 
 from backend.src.database.crud.api_key_model import *
 from backend.src.database.models.user_model import User
 from backend.src.database.session import get_db
-from backend.src.schemas.model.api_key_schema import ApiKeySchema, ApiKeyCreate, ApiKeyAuthSchema, ApiKeyUpdate
+from backend.src.schemas.model.api_key_schema import *
 from backend.src.services.auth.auth_service import get_current_active_user
 
 api_key_router = APIRouter(
@@ -13,43 +14,28 @@ api_key_router = APIRouter(
     tags=["API Keys"]
 )
 
-@api_key_router.get("/", response_model=List[ApiKeyAuthSchema])
+@api_key_router.get("/", response_model=List[ApiKeySensitiveSchema])
 def get_my_api_keys(
         db: Session = Depends(get_db),
         current_user: User = Depends(get_current_active_user)
 ):
     response = get_db_api_keys_by_user_id(db, current_user.id)
 
-    for schema in response:
-        # It is an ApiKey schema, not a dict
-        schema.encrypted_api_key = schema.api_key
-        schema.encrypted_private_key = schema.private_key
-
-        del schema.api_key
-        del schema.private_key
-
     return response
 
-@api_key_router.post("/", response_model=ApiKeySchema)
+@api_key_router.post("/", response_model=ApiKeySensitiveSchema)
 def add_api_key(
         api_key: ApiKeyCreate,
         db : Session = Depends(get_db),
         current_user: User = Depends(get_current_active_user)
 ):
-    db_api_key = get_db_api_key(db, api_key.user_id, api_key.broker_name)
+    db_api_key = get_db_api_key(db, current_user.id, api_key.broker_name)
     if db_api_key:
-        # Masking is required as the IDE will complain otherwise
-        new_api_key = ApiKeyUpdate(
-            api_key=api_key.api_key,
-            private_key=api_key.private_key,
-            broker_name=api_key.broker_name,
-            secret_key=api_key.secret_key
-        )
-        return update_db_api_key(db, new_api_key, current_user)
+        raise HTTPException(status_code=409, detail="Key already exists")
 
     return create_db_api_key(db, api_key, current_user)
 
-@api_key_router.put("/")
+@api_key_router.put("/", response_model=ApiKeySensitiveSchema)
 def update_api_key(
         new_api_key: ApiKeyUpdate,
         db: Session = Depends(get_db),
@@ -57,7 +43,7 @@ def update_api_key(
 ):
     db_api_key = get_db_api_key(db, current_user.id, new_api_key.broker_name)
     if not db_api_key:
-        return create_db_api_key(db, new_api_key, current_user)
+        raise HTTPException(status_code=404, detail="Key not found")
 
     return update_db_api_key(db, new_api_key, current_user)
 

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -6,7 +6,7 @@ from backend.src.database.crud.api_key_model import *
 from backend.src.database.crud.broker_model import get_db_broker
 from backend.src.database.models.user_model import User
 from backend.src.database.session import get_db
-from backend.src.schemas.auth.security_schema import SecurityUserPassword, SecurityUserSecretKey
+from backend.src.schemas.auth.security_schema import SecurityUserSecretKey
 from backend.src.schemas.model.api_key_schema import *
 from backend.src.services.auth.auth_service import get_current_active_user
 from backend.src.services.auth.security_service import decrypt_data
@@ -16,19 +16,12 @@ api_key_router = APIRouter(
     tags=["API Keys"]
 )
 
-@api_key_router.get("/", response_model=List[ApiKeySensitiveSchema])
+@api_key_router.get("/", response_model=List[ApiKeySensitiveSchema], description="Returns all encrypted API keys")
 def get_my_api_keys(
-        secret_key: str,
         db: Session = Depends(get_db),
         current_user: User = Depends(get_current_active_user)
 ):
-    response = get_db_api_keys_by_user_id(db, current_user.id)
-
-    for schema in response:
-        schema.api_key = decrypt_data(schema.api_key, secret_key)
-        schema.private_key = decrypt_data(schema.api_key, secret_key)
-
-    return response
+    return get_db_api_keys_by_user_id(db, current_user.id)
 
 @api_key_router.post("/", response_model=ApiKeySchema)
 def add_api_key(
@@ -45,6 +38,20 @@ def add_api_key(
         raise HTTPException(status_code=409, detail="Key already exists")
 
     return create_db_api_key(db, api_key, secret_key.secret_key, current_user)
+
+@api_key_router.post("/decrypt", response_model=List[ApiKeySensitiveSchema])
+def get_all_decoded_api_keys(
+        secret_key: SecurityUserSecretKey,
+        db: Session = Depends(get_db),
+        current_user: User = Depends(get_current_active_user)
+):
+    response = get_db_api_keys_by_user_id(db, current_user.id)
+
+    for schema in response:
+        schema.api_key = decrypt_data(str(schema.api_key), secret_key.secret_key)
+        schema.private_key = decrypt_data(str(schema.private_key), secret_key.secret_key)
+
+    return response
 
 @api_key_router.put("/", response_model=ApiKeySchema)
 def update_api_key(

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -15,11 +15,7 @@ api_key_router = APIRouter(
     tags=["API Keys"]
 )
 
-@api_key_router.get("/", response_model=List[ApiKeySchema])
-def get_all_api_keys(db: Session = Depends(get_db)):
-    return get_api_keys(db)
-
-@api_key_router.get("/me", response_model=List[ApiKeyAuthSchema])
+@api_key_router.get("/", response_model=List[ApiKeyAuthSchema])
 def get_my_api_keys(
         db: Session = Depends(get_db),
         current_user: User = Depends(get_current_active_user)

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -1,7 +1,9 @@
+from typing import List
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from backend.src.database.crud.api_key_model import create_api_key
+from backend.src.database.crud.api_key_model import create_api_key, get_api_keys
 from backend.src.database.session import get_db
 from backend.src.schemas.model.api_key_schema import ApiKeySchema, ApiKeyCreate
 
@@ -9,6 +11,10 @@ api_key_router = APIRouter(
     prefix="/apikeys",
     tags=["apikeys"]
 )
+
+@api_key_router.get("/", response_model=List[ApiKeySchema])
+def get_all_api_keys(db: Session = Depends(get_db)):
+    return get_api_keys(db)
 
 @api_key_router.post("/", response_model=ApiKeySchema)
 def add_api_key(api_key: ApiKeyCreate, db : Session = Depends(get_db)):

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -8,7 +8,7 @@ from backend.src.database.session import get_db
 from backend.src.schemas.model.api_key_schema import ApiKeySchema, ApiKeyCreate
 
 api_key_router = APIRouter(
-    prefix="/apikeys",
+    prefix="/api-keys",
     tags=["API Keys"]
 )
 

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -37,7 +37,7 @@ def add_api_key(
     if db_api_key:
         raise HTTPException(status_code=409, detail="Key already exists")
 
-    return create_db_api_key(db, api_key, secret_key.secret_key, current_user)
+    return create_db_api_key(db, api_key, secret_key.secret_key, current_user.id)
 
 @api_key_router.post("/decrypt", response_model=List[ApiKeySensitiveSchema])
 def get_all_decoded_api_keys(
@@ -67,7 +67,7 @@ def update_api_key(
     if not db_api_key:
         raise HTTPException(status_code=404, detail="Key not found")
 
-    return update_db_api_key(db, new_api_key, secret_key.secret_key, current_user)
+    return update_db_api_key(db, new_api_key, secret_key.secret_key, current_user.id)
 
 @api_key_router.delete("/{broker_name}", response_model=ApiKeySchema)
 def delete_api_key(

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -1,10 +1,8 @@
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session
 
-from backend.src.database.crud.api_key_model import create_api_key, get_api_keys, get_api_keys_by_user_id, get_api_key, \
-    delete_db_api_key
+from backend.src.database.crud.api_key_model import *
 from backend.src.database.models.user_model import User
 from backend.src.database.session import get_db
 from backend.src.schemas.model.api_key_schema import ApiKeySchema, ApiKeyCreate, ApiKeyAuthSchema, ApiKeyUpdate
@@ -20,7 +18,7 @@ def get_my_api_keys(
         db: Session = Depends(get_db),
         current_user: User = Depends(get_current_active_user)
 ):
-    response = get_api_keys_by_user_id(db, current_user.id)
+    response = get_db_api_keys_by_user_id(db, current_user.id)
 
     for schema in response:
         # It is an ApiKey schema, not a dict
@@ -38,7 +36,7 @@ def add_api_key(
         db : Session = Depends(get_db),
         current_user: User = Depends(get_current_active_user)
 ):
-    db_api_key = get_api_key(db, api_key.user_id, api_key.broker_name)
+    db_api_key = get_db_api_key(db, api_key.user_id, api_key.broker_name)
     if db_api_key:
         # Masking is required as the IDE will complain otherwise
         new_api_key = ApiKeyUpdate(
@@ -47,9 +45,9 @@ def add_api_key(
             broker_name=api_key.broker_name,
             secret_key=api_key.secret_key
         )
-        return update_api_key(new_api_key, db, current_user)
+        return update_db_api_key(db, new_api_key, current_user)
 
-    return create_api_key(db, api_key, current_user)
+    return create_db_api_key(db, api_key, current_user)
 
 @api_key_router.put("/")
 def update_api_key(
@@ -57,11 +55,11 @@ def update_api_key(
         db: Session = Depends(get_db),
         current_user: User = Depends(get_current_active_user)
 ):
-    db_api_key = get_api_key(db, new_api_key.user_id, new_api_key.broker_name)
+    db_api_key = get_db_api_key(db, current_user.id, new_api_key.broker_name)
     if not db_api_key:
-        return create_api_key(db, new_api_key, current_user)
+        return create_db_api_key(db, new_api_key, current_user)
 
-    return update_api_key(new_api_key, db, current_user)
+    return update_db_api_key(db, new_api_key, current_user)
 
 @api_key_router.delete("/{broker_name}", response_model=ApiKeySchema)
 def delete_api_key(
@@ -69,7 +67,7 @@ def delete_api_key(
         db: Session = Depends(get_db),
         current_user: User = Depends(get_current_active_user)
 ):
-    db_api_key = get_api_key(db, current_user.id, broker_name)
+    db_api_key = get_db_api_key(db, current_user.id, broker_name)
     if db_api_key is None:
         raise HTTPException(status_code=404, detail="API Key not found")
 

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from backend.src.database.crud.api_key_model import create_api_key
+from backend.src.database.session import get_db
+from backend.src.schemas.model.api_key_schema import ApiKeySchema, ApiKeyCreate
+
+api_key_router = APIRouter(
+    prefix="/apikeys",
+    tags=["apikeys"]
+)
+
+@api_key_router.post("/", response_model=ApiKeySchema)
+def add_api_key(api_key: ApiKeyCreate, db : Session = Depends(get_db)):
+    return create_api_key(db, api_key)

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -7,7 +7,7 @@ from backend.src.database.crud.api_key_model import create_api_key, get_api_keys
 from backend.src.database.models.user_model import User
 from backend.src.database.session import get_db
 from backend.src.schemas.model.api_key_schema import ApiKeySchema, ApiKeyCreate
-from backend.src.services.auth.auth_service import get_current_user, get_current_active_user
+from backend.src.services.auth.auth_service import get_current_active_user
 
 api_key_router = APIRouter(
     prefix="/api-keys",

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -1,12 +1,13 @@
 from typing import List
 
 from fastapi import APIRouter, Depends
+from pycparser.c_ast import Return
 from sqlalchemy.orm import Session
 
-from backend.src.database.crud.api_key_model import create_api_key, get_api_keys
+from backend.src.database.crud.api_key_model import create_api_key, get_api_keys, get_api_keys_by_user_id
 from backend.src.database.models.user_model import User
 from backend.src.database.session import get_db
-from backend.src.schemas.model.api_key_schema import ApiKeySchema, ApiKeyCreate
+from backend.src.schemas.model.api_key_schema import ApiKeySchema, ApiKeyCreate, ApiKeyAuthSchema
 from backend.src.services.auth.auth_service import get_current_active_user
 
 api_key_router = APIRouter(
@@ -17,6 +18,23 @@ api_key_router = APIRouter(
 @api_key_router.get("/", response_model=List[ApiKeySchema])
 def get_all_api_keys(db: Session = Depends(get_db)):
     return get_api_keys(db)
+
+@api_key_router.get("/me", response_model=List[ApiKeyAuthSchema])
+def get_my_api_keys(
+        db: Session = Depends(get_db),
+        current_user: User = Depends(get_current_active_user)
+):
+    response = get_api_keys_by_user_id(db, current_user.id)
+
+    for schema in response:
+        # It is an ApiKey schema, not a dict
+        schema.encrypted_api_key = schema.api_key
+        schema.encrypted_private_key = schema.private_key
+
+        del schema.api_key
+        del schema.private_key
+
+    return response
 
 @api_key_router.post("/", response_model=ApiKeySchema)
 def add_api_key(

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -1,4 +1,4 @@
-from typing import List, Any
+from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
 
@@ -6,8 +6,10 @@ from backend.src.database.crud.api_key_model import *
 from backend.src.database.crud.broker_model import get_db_broker
 from backend.src.database.models.user_model import User
 from backend.src.database.session import get_db
+from backend.src.schemas.auth.security_schema import SecurityUserPassword, SecurityUserSecretKey
 from backend.src.schemas.model.api_key_schema import *
 from backend.src.services.auth.auth_service import get_current_active_user
+from backend.src.services.auth.security_service import decrypt_data
 
 api_key_router = APIRouter(
     prefix="/api-keys",
@@ -16,16 +18,22 @@ api_key_router = APIRouter(
 
 @api_key_router.get("/", response_model=List[ApiKeySensitiveSchema])
 def get_my_api_keys(
+        secret_key: str,
         db: Session = Depends(get_db),
         current_user: User = Depends(get_current_active_user)
 ):
     response = get_db_api_keys_by_user_id(db, current_user.id)
 
+    for schema in response:
+        schema.api_key = decrypt_data(schema.api_key, secret_key)
+        schema.private_key = decrypt_data(schema.api_key, secret_key)
+
     return response
 
-@api_key_router.post("/", response_model=ApiKeySensitiveSchema)
+@api_key_router.post("/", response_model=ApiKeySchema)
 def add_api_key(
         api_key: ApiKeyCreate,
+        secret_key: SecurityUserSecretKey,
         db : Session = Depends(get_db),
         current_user: User = Depends(get_current_active_user)
 ):
@@ -36,11 +44,12 @@ def add_api_key(
     if db_api_key:
         raise HTTPException(status_code=409, detail="Key already exists")
 
-    return create_db_api_key(db, api_key, current_user)
+    return create_db_api_key(db, api_key, secret_key.secret_key, current_user)
 
-@api_key_router.put("/", response_model=ApiKeySensitiveSchema)
+@api_key_router.put("/", response_model=ApiKeySchema)
 def update_api_key(
         new_api_key: ApiKeyUpdate,
+        secret_key: SecurityUserSecretKey,
         db: Session = Depends(get_db),
         current_user: User = Depends(get_current_active_user)
 ):
@@ -51,7 +60,7 @@ def update_api_key(
     if not db_api_key:
         raise HTTPException(status_code=404, detail="Key not found")
 
-    return update_db_api_key(db, new_api_key, current_user)
+    return update_db_api_key(db, new_api_key, secret_key.secret_key, current_user)
 
 @api_key_router.delete("/{broker_name}", response_model=ApiKeySchema)
 def delete_api_key(

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -1,7 +1,6 @@
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
-from pycparser.c_ast import Return
 from sqlalchemy.orm import Session
 
 from backend.src.database.crud.api_key_model import create_api_key, get_api_keys, get_api_keys_by_user_id, get_api_key, \

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -4,8 +4,10 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from backend.src.database.crud.api_key_model import create_api_key, get_api_keys
+from backend.src.database.models.user_model import User
 from backend.src.database.session import get_db
 from backend.src.schemas.model.api_key_schema import ApiKeySchema, ApiKeyCreate
+from backend.src.services.auth.auth_service import get_current_active_user
 
 api_key_router = APIRouter(
     prefix="/api-keys",
@@ -17,5 +19,9 @@ def get_all_api_keys(db: Session = Depends(get_db)):
     return get_api_keys(db)
 
 @api_key_router.post("/", response_model=ApiKeySchema)
-def add_api_key(api_key: ApiKeyCreate, db : Session = Depends(get_db)):
-    return create_api_key(db, api_key)
+def add_api_key(
+        api_key: ApiKeyCreate,
+        db : Session = Depends(get_db),
+        current_user: User = get_current_active_user()
+):
+    return create_api_key(db, api_key, current_user)

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -7,7 +7,7 @@ from backend.src.database.crud.api_key_model import create_api_key, get_api_keys
 from backend.src.database.models.user_model import User
 from backend.src.database.session import get_db
 from backend.src.schemas.model.api_key_schema import ApiKeySchema, ApiKeyCreate
-from backend.src.services.auth.auth_service import get_current_active_user
+from backend.src.services.auth.auth_service import get_current_user, get_current_active_user
 
 api_key_router = APIRouter(
     prefix="/api-keys",
@@ -22,6 +22,6 @@ def get_all_api_keys(db: Session = Depends(get_db)):
 def add_api_key(
         api_key: ApiKeyCreate,
         db : Session = Depends(get_db),
-        current_user: User = get_current_active_user()
+        current_user: User = Depends(get_current_active_user)
 ):
     return create_api_key(db, api_key, current_user)

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -1,10 +1,11 @@
 from typing import List
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pycparser.c_ast import Return
 from sqlalchemy.orm import Session
 
-from backend.src.database.crud.api_key_model import create_api_key, get_api_keys, get_api_keys_by_user_id
+from backend.src.database.crud.api_key_model import create_api_key, get_api_keys, get_api_keys_by_user_id, get_api_key, \
+    delete_db_api_key
 from backend.src.database.models.user_model import User
 from backend.src.database.session import get_db
 from backend.src.schemas.model.api_key_schema import ApiKeySchema, ApiKeyCreate, ApiKeyAuthSchema
@@ -39,3 +40,15 @@ def add_api_key(
         current_user: User = Depends(get_current_active_user)
 ):
     return create_api_key(db, api_key, current_user)
+
+@api_key_router.delete("/{broker_name}", response_model=ApiKeySchema)
+def delete_api_key(
+        broker_name: str,
+        db: Session = Depends(get_db),
+        current_user: User = Depends(get_current_active_user)
+):
+    db_api_key = get_api_key(db, current_user.id, broker_name)
+    if db_api_key is None:
+        raise HTTPException(status_code=404, detail="API Key not found")
+
+    return delete_db_api_key(db, db_api_key, current_user.id)

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -8,7 +8,7 @@ from backend.src.database.crud.api_key_model import create_api_key, get_api_keys
     delete_db_api_key
 from backend.src.database.models.user_model import User
 from backend.src.database.session import get_db
-from backend.src.schemas.model.api_key_schema import ApiKeySchema, ApiKeyCreate, ApiKeyAuthSchema
+from backend.src.schemas.model.api_key_schema import ApiKeySchema, ApiKeyCreate, ApiKeyAuthSchema, ApiKeyUpdate
 from backend.src.services.auth.auth_service import get_current_active_user
 
 api_key_router = APIRouter(
@@ -40,6 +40,18 @@ def add_api_key(
         current_user: User = Depends(get_current_active_user)
 ):
     return create_api_key(db, api_key, current_user)
+
+@api_key_router.put("/")
+def update_api_key(
+        new_api_key: ApiKeyUpdate,
+        db: Session = Depends(get_db),
+        current_user: User = Depends(get_current_active_user)
+):
+    db_api_key = get_api_key(db, new_api_key.user_id, new_api_key.broker_name)
+    if not db_api_key:
+        return create_api_key(db, new_api_key, current_user)
+
+    return update_api_key(new_api_key, db, current_user)
 
 @api_key_router.delete("/{broker_name}", response_model=ApiKeySchema)
 def delete_api_key(

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -39,6 +39,17 @@ def add_api_key(
         db : Session = Depends(get_db),
         current_user: User = Depends(get_current_active_user)
 ):
+    db_api_key = get_api_key(db, api_key.user_id, api_key.broker_name)
+    if db_api_key:
+        # Masking is required as the IDE will complain otherwise
+        new_api_key = ApiKeyUpdate(
+            api_key=api_key.api_key,
+            private_key=api_key.private_key,
+            broker_name=api_key.broker_name,
+            secret_key=api_key.secret_key
+        )
+        return update_api_key(new_api_key, db, current_user)
+
     return create_api_key(db, api_key, current_user)
 
 @api_key_router.put("/")

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -9,7 +9,7 @@ from backend.src.schemas.model.api_key_schema import ApiKeySchema, ApiKeyCreate
 
 api_key_router = APIRouter(
     prefix="/apikeys",
-    tags=["apikeys"]
+    tags=["API Keys"]
 )
 
 @api_key_router.get("/", response_model=List[ApiKeySchema])

--- a/backend/src/routes/models/api_key_router.py
+++ b/backend/src/routes/models/api_key_router.py
@@ -1,9 +1,9 @@
 from typing import List, Any
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
 
 from backend.src.database.crud.api_key_model import *
+from backend.src.database.crud.broker_model import get_db_broker
 from backend.src.database.models.user_model import User
 from backend.src.database.session import get_db
 from backend.src.schemas.model.api_key_schema import *
@@ -29,6 +29,9 @@ def add_api_key(
         db : Session = Depends(get_db),
         current_user: User = Depends(get_current_active_user)
 ):
+    if not get_db_broker(db, api_key.broker_name):
+        raise HTTPException(status_code=404, detail="Broker not found")
+
     db_api_key = get_db_api_key(db, current_user.id, api_key.broker_name)
     if db_api_key:
         raise HTTPException(status_code=409, detail="Key already exists")
@@ -41,6 +44,9 @@ def update_api_key(
         db: Session = Depends(get_db),
         current_user: User = Depends(get_current_active_user)
 ):
+    if not get_db_broker(db, new_api_key.broker_name):
+        raise HTTPException(status_code=404, detail="Broker not found")
+
     db_api_key = get_db_api_key(db, current_user.id, new_api_key.broker_name)
     if not db_api_key:
         raise HTTPException(status_code=404, detail="Key not found")
@@ -53,6 +59,9 @@ def delete_api_key(
         db: Session = Depends(get_db),
         current_user: User = Depends(get_current_active_user)
 ):
+    if not get_db_broker(db, broker_name):
+        raise HTTPException(status_code=404, detail="Broker not found")
+
     db_api_key = get_db_api_key(db, current_user.id, broker_name)
     if db_api_key is None:
         raise HTTPException(status_code=404, detail="API Key not found")

--- a/backend/src/routes/models/broker_router.py
+++ b/backend/src/routes/models/broker_router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from backend.src.database.crud.broker_model import get_brokers
+from backend.src.database.crud.broker_model import get_db_brokers
 from backend.src.database.session import get_db
 
 broker_router = APIRouter(
@@ -11,4 +11,4 @@ broker_router = APIRouter(
 
 @broker_router.get("/")
 def get_all_brokers(db : Session = Depends(get_db)):
-    return get_brokers(db)
+    return get_db_brokers(db)

--- a/backend/src/routes/models/broker_router.py
+++ b/backend/src/routes/models/broker_router.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from backend.src.database.crud.broker_model import get_brokers
+from backend.src.database.session import get_db
+
+broker_router = APIRouter(
+    prefix="/brokers",
+    tags=["Brokers"]
+)
+
+@broker_router.get("/")
+def get_all_brokers(db : Session = Depends(get_db)):
+    return get_brokers(db)

--- a/backend/src/routes/models/user_router.py
+++ b/backend/src/routes/models/user_router.py
@@ -12,13 +12,13 @@ user_router = APIRouter(
     tags=["users"]
 )
 
-@user_router.get("/me", response_model=UserSchema)
-def me(current_user: User = Depends(get_current_active_user)):
-    return current_user
-
 @user_router.get("/", response_model=List[UserSchema])
 def get_all_users(db: Session = Depends(get_db)):
     return get_users(db)
+
+@user_router.get("/me", response_model=UserSchema)
+def me(current_user: User = Depends(get_current_active_user)):
+    return current_user
 
 @user_router.get("/{user_id}", response_model=UserSchema)
 def get_user_by_id(user_id: int, db: Session = Depends(get_db)):

--- a/backend/src/routes/models/user_router.py
+++ b/backend/src/routes/models/user_router.py
@@ -14,7 +14,7 @@ user_router = APIRouter(
 
 @user_router.get("/", response_model=List[UserSchema])
 def get_all_users(db: Session = Depends(get_db)):
-    return get_users(db)
+    return get_db_users(db)
 
 @user_router.get("/me", response_model=UserSchema)
 def me(current_user: User = Depends(get_current_active_user)):
@@ -22,7 +22,7 @@ def me(current_user: User = Depends(get_current_active_user)):
 
 @user_router.get("/{user_id}", response_model=UserSchema)
 def get_user_by_id(user_id: int, db: Session = Depends(get_db)):
-    db_user = get_user(db, user_id)
+    db_user = get_db_user(db, user_id)
     if db_user is None:
         raise HTTPException(status_code=404, detail="User not found")
 
@@ -30,6 +30,6 @@ def get_user_by_id(user_id: int, db: Session = Depends(get_db)):
 
 @user_router.post("/", response_model=UserSchema)
 def create_new_user(user: UserCreate, db: Session = Depends(get_db)):
-    return create_user(db, user)
+    return create_db_user(db, user)
 
 

--- a/backend/src/routes/models/user_router.py
+++ b/backend/src/routes/models/user_router.py
@@ -9,7 +9,7 @@ from backend.src.services.auth.auth_service import get_current_active_user
 
 user_router = APIRouter(
     prefix="/users",
-    tags=["users"]
+    tags=["Users"]
 )
 
 @user_router.get("/", response_model=List[UserSchema])

--- a/backend/src/schemas/auth/security_schema.py
+++ b/backend/src/schemas/auth/security_schema.py
@@ -1,7 +1,0 @@
-from pydantic import BaseModel
-
-class DeriveKeyRequest(BaseModel):
-    password: str
-
-class ResponseSchema(BaseModel):
-    response: str

--- a/backend/src/schemas/auth/security_schema.py
+++ b/backend/src/schemas/auth/security_schema.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class SecurityUserPassword(BaseModel):
+    password: str
+
+class SecurityUserSecretKey(BaseModel):
+    secret_key: str

--- a/backend/src/schemas/auth/security_schema.py
+++ b/backend/src/schemas/auth/security_schema.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+class DeriveKeyRequest(BaseModel):
+    password: str
+
+class ResponseSchema(BaseModel):
+    response: str

--- a/backend/src/schemas/model/api_key_schema.py
+++ b/backend/src/schemas/model/api_key_schema.py
@@ -7,13 +7,11 @@ class ApiKeyBase(BaseModel):
 class ApiKeySchema(ApiKeyBase):
     user_id : int
 
-class ApiKeyAuthSchema(ApiKeySchema):
-    encrypted_api_key: str
-    encrypted_private_key: str
-
-class ApiKeyCreate(ApiKeyBase):
+class ApiKeySensitiveSchema(ApiKeyBase):
     api_key: str
     private_key: str
+
+class ApiKeyCreate(ApiKeySensitiveSchema):
     secret_key: str
 
 class ApiKeyUpdate(ApiKeyCreate):

--- a/backend/src/schemas/model/api_key_schema.py
+++ b/backend/src/schemas/model/api_key_schema.py
@@ -2,11 +2,10 @@ from pydantic import BaseModel
 
 
 class ApiKeyBase(BaseModel):
-    user_id: int
     broker_name: str
 
 class ApiKeySchema(ApiKeyBase):
-    pass
+    user_id : int
 
 class ApiKeyCreate(ApiKeyBase):
     api_key: str

--- a/backend/src/schemas/model/api_key_schema.py
+++ b/backend/src/schemas/model/api_key_schema.py
@@ -20,5 +20,5 @@ class ApiKeyCreate(ApiKeySensitive):
 class ApiKeyUpdate(ApiKeySensitive):
     pass
 
-class ApiKeyDelete(ApiKeySensitive):
+class ApiKeyDelete(ApiKeyBase):
     pass

--- a/backend/src/schemas/model/api_key_schema.py
+++ b/backend/src/schemas/model/api_key_schema.py
@@ -11,3 +11,4 @@ class ApiKeySchema(ApiKeyBase):
 class ApiKeyCreate(ApiKeyBase):
     api_key: str
     private_key: str
+    secret_key: str

--- a/backend/src/schemas/model/api_key_schema.py
+++ b/backend/src/schemas/model/api_key_schema.py
@@ -7,15 +7,18 @@ class ApiKeyBase(BaseModel):
 class ApiKeySchema(ApiKeyBase):
     user_id : int
 
-class ApiKeySensitiveSchema(ApiKeyBase):
+class ApiKeySensitive(ApiKeyBase):
     api_key: str
     private_key: str
 
-class ApiKeyCreate(ApiKeySensitiveSchema):
-    secret_key: str
-
-class ApiKeyUpdate(ApiKeyCreate):
+class ApiKeySensitiveSchema(ApiKeySensitive, ApiKeySchema):
     pass
 
-class ApiKeyDelete(ApiKeyCreate):
+class ApiKeyCreate(ApiKeySensitive):
+    pass
+
+class ApiKeyUpdate(ApiKeySensitive):
+    pass
+
+class ApiKeyDelete(ApiKeySensitive):
     pass

--- a/backend/src/schemas/model/api_key_schema.py
+++ b/backend/src/schemas/model/api_key_schema.py
@@ -7,7 +7,17 @@ class ApiKeyBase(BaseModel):
 class ApiKeySchema(ApiKeyBase):
     user_id : int
 
+class ApiKeyAuthSchema(ApiKeySchema):
+    encrypted_api_key: str
+    encrypted_private_key: str
+
 class ApiKeyCreate(ApiKeyBase):
     api_key: str
     private_key: str
     secret_key: str
+
+class ApiKeyUpdate(ApiKeyCreate):
+    pass
+
+class ApiKeyDelete(ApiKeyCreate):
+    pass

--- a/backend/src/services/auth/auth_service.py
+++ b/backend/src/services/auth/auth_service.py
@@ -104,7 +104,3 @@ async def get_current_user(
         raise credentials_exception
 
     return user
-
-async def get_current_active_user(current_user: User = Depends(get_current_user)):
-    """Get user from the token, handled by FastAPI Dependency Injection."""
-    return current_user

--- a/backend/src/services/auth/auth_service.py
+++ b/backend/src/services/auth/auth_service.py
@@ -8,7 +8,7 @@ from jwt import InvalidTokenError
 from sqlalchemy.orm import Session
 
 from backend.src.core.config import settings
-from backend.src.database.crud.user_crud import get_user_by_email
+from backend.src.database.crud.user_crud import get_db_user_by_email
 from backend.src.database.models.user_model import User
 from backend.src.database.session import get_db
 from backend.src.schemas.auth.token_schema import TokenData
@@ -29,7 +29,7 @@ def authenticate_user(email: str, password: str, db: Session = Depends(get_db)) 
     :return: User Schema if the user is authenticated, False otherwise.
     """
 
-    user = get_user_by_email(db, email)
+    user = get_db_user_by_email(db, email)
     if not user:
         return False
 
@@ -99,7 +99,7 @@ async def get_current_user(
     except InvalidTokenError:
         raise credentials_exception
 
-    user = get_user_by_email(db, email=token_data.email)
+    user = get_db_user_by_email(db, email=token_data.email)
     if user is None:
         raise credentials_exception
 

--- a/backend/src/services/auth/auth_service.py
+++ b/backend/src/services/auth/auth_service.py
@@ -104,3 +104,7 @@ async def get_current_user(
         raise credentials_exception
 
     return user
+
+async def get_current_active_user(current_user: User = Depends(get_current_user)):
+    """Get user from the token, handled by FastAPI Dependency Injection."""
+    return current_user

--- a/backend/test/conftest.py
+++ b/backend/test/conftest.py
@@ -1,0 +1,25 @@
+import pytest
+
+from backend.src.database.models.user_model import User
+from backend.src.database.session import get_db
+from backend.src.main import app
+from backend.src.services.auth.auth_service import get_current_active_user
+from backend.test.database.test_session import db
+
+
+@pytest.fixture(scope="session")
+def dummy_active_user():
+    return User(id=3, email="dummy@user.com", password="not_real")
+
+@pytest.fixture(scope="function", autouse=True)
+def override_dependencies(dummy_active_user, db):
+    def _get_db_override():
+        yield db
+
+    app.dependency_overrides[get_db] = _get_db_override
+
+    app.dependency_overrides[get_current_active_user] = lambda: dummy_active_user
+
+    yield
+
+    app.dependency_overrides.clear()

--- a/backend/test/database/crud/test_api_key_model.py
+++ b/backend/test/database/crud/test_api_key_model.py
@@ -1,0 +1,69 @@
+import pytest
+from cryptography.fernet import Fernet
+
+from backend.src.database.crud.api_key_model import *
+from backend.src.database.crud.broker_model import get_db_brokers
+from backend.src.database.crud.user_crud import create_db_user
+from backend.src.schemas.model.api_key_schema import ApiKeyCreate
+from backend.src.schemas.model.user_schema import UserCreate
+from backend.test.database.test_session import db
+
+@pytest.fixture
+def setup_users_db(db):
+
+    db_user = create_db_user(db, UserCreate(email="apikey@test.com", password="hashed"))
+    get_db_brokers(db) # Load brokers table
+
+    return db_user
+
+@pytest.fixture
+def generate_secret_key():
+    key = Fernet.generate_key()
+    return key.decode("utf-8")
+
+
+def test_crud_operations(db, setup_users_db, generate_secret_key):
+    assert get_db_api_keys(db) == []
+
+    db_api_key = create_db_api_key(
+        db,
+        ApiKeyCreate(
+            broker_name="Trading212",
+            api_key="Random",
+            private_key="Random",
+        ),
+        generate_secret_key,
+        setup_users_db.id
+    )
+
+    assert get_db_api_keys(db) == [db_api_key]
+    assert get_db_api_keys_by_user_id(db, setup_users_db.id) == [db_api_key]
+    assert get_db_api_key(db, setup_users_db.id, "Trading212") == db_api_key
+
+    old_api_key = str(db_api_key.api_key)
+
+    new_db_api_key = update_db_api_key(
+        db,
+        ApiKeyUpdate(
+            broker_name="Trading212",
+            api_key="NotARealApiKey",
+            private_key="NotARealApiKey"
+        ),
+        generate_secret_key,
+        setup_users_db.id
+    )
+
+    assert not new_db_api_key.api_key == old_api_key
+
+    delete_db_api_key(
+        db,
+        ApiKeyDelete(
+            broker_name="Trading212",
+        ),
+        setup_users_db.id
+    )
+
+    assert get_db_api_keys(db) == []
+
+
+

--- a/backend/test/database/crud/test_broker_model.py
+++ b/backend/test/database/crud/test_broker_model.py
@@ -2,9 +2,6 @@ from backend.src.database.crud.broker_model import get_db_brokers, add_broker_fr
 from backend.test.database.test_session import db
 
 def test_add_broker_from_file(db):
-    # Ensure that the db is empty before,
-    # Then add brokers from file
-    # Assert that it is not empty.
-    assert get_db_brokers(db) == []
-    add_broker_from_file(db)
+    # get_brokers_from_file is called on db setup
+
     assert not get_db_brokers(db) == []

--- a/backend/test/database/crud/test_broker_model.py
+++ b/backend/test/database/crud/test_broker_model.py
@@ -1,10 +1,10 @@
-from backend.src.database.crud.broker_model import get_brokers, add_broker_from_file
+from backend.src.database.crud.broker_model import get_db_brokers, add_broker_from_file
 from backend.test.database.test_session import db
 
 def test_add_broker_from_file(db):
     # Ensure that the db is empty before,
     # Then add brokers from file
     # Assert that it is not empty.
-    assert get_brokers(db) == []
+    assert get_db_brokers(db) == []
     add_broker_from_file(db)
-    assert not get_brokers(db) == []
+    assert not get_db_brokers(db) == []

--- a/backend/test/database/crud/test_user_crud.py
+++ b/backend/test/database/crud/test_user_crud.py
@@ -11,15 +11,15 @@ def test_create_user_and_get_user(db: Session):
         password="test"
     )
 
-    new_user = create_user(db, user)
+    new_user = create_db_user(db, user)
 
-    assert get_user(db, new_user.id) == new_user
-    assert get_user_by_email(db, new_user.email) == new_user
+    assert get_db_user(db, new_user.id) == new_user
+    assert get_db_user_by_email(db, new_user.email) == new_user
 
     assert new_user.password != user.password
 
-    assert isinstance(get_users(db), list)
-    assert len(get_users(db)) == 1
+    assert isinstance(get_db_users(db), list)
+    assert len(get_db_users(db)) == 1
 
-    create_user(db, user2)
-    assert len(get_users(db)) == 2
+    create_db_user(db, user2)
+    assert len(get_db_users(db)) == 2

--- a/backend/test/database/test_session.py
+++ b/backend/test/database/test_session.py
@@ -3,6 +3,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.orm.session import Session, sessionmaker
 
 from backend.src.core.config import settings
+from backend.src.database.crud.broker_model import add_broker_from_file
 from backend.src.database.session import get_db, Base
 
 
@@ -18,6 +19,9 @@ def db() -> Session:
         Base.metadata.create_all(bind=conn)
 
     db_session = SessionLocal()
+
+    add_broker_from_file(db_session)
+
     try:
         yield db_session
     finally:

--- a/backend/test/routes/auth/test_auth_router.py
+++ b/backend/test/routes/auth/test_auth_router.py
@@ -2,7 +2,7 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
-from backend.src.database.crud.user_crud import create_user
+from backend.src.database.crud.user_crud import create_db_user
 from backend.src.database.session import get_db
 from backend.src.main import app
 from backend.src.schemas.model.user_schema import UserCreate
@@ -34,7 +34,7 @@ def test_login_for_access_token(db):
         email="success@test.com",
         password="something"
     )
-    create_user(db, new_user)
+    create_db_user(db, new_user)
     response = client.post(
         f"{url_prefix}/login",
         data={"username": new_user.email, "password": new_user.password},

--- a/backend/test/routes/auth/test_security_router.py
+++ b/backend/test/routes/auth/test_security_router.py
@@ -1,0 +1,30 @@
+from fastapi.testclient import TestClient
+
+from backend.test.conftest import *
+
+client = TestClient(app)
+url_prefix = "/api/encryption"
+
+def test_derive_key_function():
+    response = client.post(
+        f"{url_prefix}/derive-key",
+        json={"password": "test"}
+    )
+    assert response.status_code == 200
+    secret_key_test1 = response.json()
+
+    response = client.post(
+        f"{url_prefix}/derive-key",
+        json={"password": "test"}
+    )
+    secret_key_test2 = response.json()
+
+    response = client.post(
+        f"{url_prefix}/derive-key",
+        json={"password": "family_guy"}
+    )
+    secret_key_family_guy3 = response.json()
+
+    assert isinstance(secret_key_test1, str)
+    assert secret_key_test1 != secret_key_family_guy3
+    assert secret_key_test1 == secret_key_test2 # Deterministic

--- a/backend/test/routes/models/test_api_key_router.py
+++ b/backend/test/routes/models/test_api_key_router.py
@@ -1,17 +1,9 @@
-import pytest
 from fastapi.testclient import TestClient
 
-from backend.src.database.session import get_db
-from backend.src.main import app
+from backend.test.conftest import *
 
 client = TestClient(app)
 url_prefix = "/api/api-keys"
-
-@pytest.fixture(autouse=True)
-def override_dependency_db(db):
-    def _get_db_override():
-        yield db
-    app.dependency_overrides[get_db] = _get_db_override
 
 def create_and_delete_api_keys():
     pass

--- a/backend/test/routes/models/test_api_key_router.py
+++ b/backend/test/routes/models/test_api_key_router.py
@@ -4,7 +4,7 @@ from fastapi.testclient import TestClient
 from backend.src.database.session import get_db
 from backend.src.main import app
 
-client = TestClient()
+client = TestClient(app)
 url_prefix = "/api/api-keys"
 
 @pytest.fixture(autouse=True)

--- a/backend/test/routes/models/test_api_key_router.py
+++ b/backend/test/routes/models/test_api_key_router.py
@@ -1,0 +1,17 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.src.database.session import get_db
+from backend.src.main import app
+
+client = TestClient()
+url_prefix = "/api/api-keys"
+
+@pytest.fixture(autouse=True)
+def override_dependency_db(db):
+    def _get_db_override():
+        yield db
+    app.dependency_overrides[get_db] = _get_db_override
+
+def create_and_delete_api_keys():
+    pass

--- a/backend/test/services/auth/test_auth_service.py
+++ b/backend/test/services/auth/test_auth_service.py
@@ -1,6 +1,6 @@
 import pytest
 
-from backend.src.database.crud.user_crud import create_user
+from backend.src.database.crud.user_crud import create_db_user
 from backend.src.schemas.model.user_schema import UserCreate, UserSchema
 from backend.src.services.auth.auth_service import *
 from backend.test.database.test_session import db
@@ -13,7 +13,7 @@ def test_authenticate_user(db):
         email="real@user.com",
         password="password"
     )
-    create_user(db, new_user)
+    create_db_user(db, new_user)
 
     assert not authenticate_user(new_user.email, "wrong_password", db)
 
@@ -52,7 +52,7 @@ async def test_get_current_user(db):
         email="not@real.com",
         password="test"
     )
-    db_user = create_user(db, new_user)
+    db_user = create_db_user(db, new_user)
     returned_user = await get_current_user(token, db)
     assert db_user.email ==  returned_user.email
 


### PR DESCRIPTION
## Final Deliverables
- Add tables for `api_keys` and `broker` with relationships
- Add `api_keys_router` with CRUD operations
  - OAuth2 with JWT ensures you only receive your API keys
  - Add ability to POST unencrypted api keys and GET encrypted api keys
    - Able to derive secret key with `security` endpoints
- Pass sensitive credentials with pydantic schemas, use OAuth2 scheme for every sensitive endpoint as a requirement
- Test cases
  - Global overrides for `get_db` and `get_current_active_user`
  - No test cases implementation for `api_keys_router` due to incoming requirements that will affect the endpoints
     - API verification

Closes #36 

Good night.