### PR TITLE
#42 Intercept protectedApi error responses to check if user is unauth…

### DIFF
--- a/frontend/src/config/axios.config.tsx
+++ b/frontend/src/config/axios.config.tsx
@@ -25,4 +25,15 @@ protectedApi.interceptors.request.use(
     (error) => Promise.reject(error)
 )
 
+protectedApi.interceptors.response.use(
+    (response) => {
+        return response;
+    },
+    (error) => {
+        if (error.response && error.response.status === 401 && error.response.data.detail === "Not authenticated") {
+            window.location.href = "/login";
+        }
+    }
+)
+
 export { api, protectedApi };


### PR DESCRIPTION
## Deliverables
- Any `401 HTTPError` will send the user to `/login` page